### PR TITLE
Add domain to base_domain- fix atom links

### DIFF
--- a/blog_zola/config.toml
+++ b/blog_zola/config.toml
@@ -1,5 +1,5 @@
 # The URL the site will be built for
-base_url = "/blog"
+base_url = "www.macchaffee.com/blog"
 title = "Mac's Tech Blog"
 description = "Mac's Tech Blog"
 author = "Mac"


### PR DESCRIPTION
Hello! I enjoy reading your blog, but your [atom feed](https://www.macchaffee.com/blog/atom.xml) contains only relative links.

I'm not sure if this is in the spec, but from what rss/atom feeds I follow, only yours doesn't use absolute links.

This unfortunately breaks local viewing of the blog, as a alternative you could add your own [atom feed template](https://github.com/getzola/zola/blob/master/components/templates/src/builtins/atom.xml) and another config entry- something like:
`base_domain = www.macchaffee.com`
And somehow changing all the links.

Either way, I hope you can fix this issue.